### PR TITLE
Fix issue #4 "Time zone for "GTB Standard Time" wrong?"

### DIFF
--- a/TimeZones/src/TimeZoneList.java
+++ b/TimeZones/src/TimeZoneList.java
@@ -49,7 +49,8 @@ public class TimeZoneList {
 		ZONEMAPPINGS.add(new TimeZoneMapping("GMT Standard Time", "Europe/London", "(GMT) Dublin, Edinburgh, Lisbon, London"));
 		ZONEMAPPINGS.add(new TimeZoneMapping("Greenland Standard Time", "America/Godthab", "(GMT -03:00) Greenland"));
 		ZONEMAPPINGS.add(new TimeZoneMapping("Greenwich Standard Time", "Atlantic/Reykjavik", "(GMT) Monrovia, Reykjavik"));
-		ZONEMAPPINGS.add(new TimeZoneMapping("GTB Standard Time", "Europe/Istanbul", "(GMT +02:00) Athens, Bucharest, Istanbul"));
+		ZONEMAPPINGS.add(new TimeZoneMapping("GTB Standard Time", "Europe/Athens", "(GMT +02:00) Athens, Bucharest"));
+		ZONEMAPPINGS.add(new TimeZoneMapping("Turkey Time", "Europe/Istanbul", "(GMT +03:00) Istanbul"));
 		ZONEMAPPINGS.add(new TimeZoneMapping("Hawaiian Standard Time", "Pacific/Honolulu", "(GMT -10:00) Hawaii"));
 		ZONEMAPPINGS.add(new TimeZoneMapping("India Standard Time", "Asia/Calcutta", "(GMT +05:30) Chennai, Kolkata, Mumbai, New Delhi"));
 		ZONEMAPPINGS.add(new TimeZoneMapping("Iran Standard Time", "Asia/Tehran", "(GMT +03:30) Tehran"));


### PR DESCRIPTION
EDITED GTB Standard Time, was located in Europe/Istanbul, now is Europe/Athens.
REMOVED Istanbul from GTB Standard Time windowsDisplayName field.
ADDED Turkey Time (TRT) for Istanbul